### PR TITLE
Handle "delimited-identifier" tag parsing

### DIFF
--- a/src/main/java/org/datanucleus/api/jakarta/metadata/JakartaXmlMetaDataHandler.java
+++ b/src/main/java/org/datanucleus/api/jakarta/metadata/JakartaXmlMetaDataHandler.java
@@ -423,6 +423,10 @@ public class JakartaXmlMetaDataHandler extends AbstractXmlMetaDataHandler
                 FileMetaData filemd = (FileMetaData)getStack();
                 filemd.setType(MetaDataFileType.JPA_MAPPING_FILE);
             }
+            else if (localName.equals("delimited-identifiers"))
+            {
+            	//TODO just added to stop breaking metadata parsing. Not functional yet.
+            }
             else if (localName.equals("description"))
             {
                 // Of no practical use so ignored


### PR DESCRIPTION
Datanucleus by default uses delimited identifiers, so this feature does not add much functional value. This change just avoid breaking metadata parsing when "delimited-identifier" tag is present. It does not change anything functionally.